### PR TITLE
fix ko repo rename

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d # tag=v0.5
+    - uses: imjasonh/setup-ko@v0.6
     - run: ko publish ./


### PR DESCRIPTION
https://github.com/imjasonh/setup-ko says:

> ⚠️ Note: ko recently https://github.com/ko-build/ko/issues/791, which broke setup-ko@v0.5 if the ko version wasn't specified.
>
> To fix this, either upgrade to [setup-ko@v0.6](https://github.com/imjasonh/setup-ko/releases/tag/v0.6) or specify version